### PR TITLE
feat: send updated eligible submission counts to relayer

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -27,6 +27,7 @@ type Settings struct {
 	DataMarketAddresses         []string
 	DataMarketContractAddresses []common.Address
 	ProcessSwitch               bool
+	SuccessNotification         bool
 }
 
 func LoadConfig() {
@@ -46,6 +47,11 @@ func LoadConfig() {
 		log.Fatalf("Failed to parse PROCESS_SWITCH environment variable: %v", processSwitchParseErr)
 	}
 
+	successNotification, successNotificationErr := strconv.ParseBool(getEnv("SUCCESS_NOTIFICATION", "true"))
+	if successNotificationErr != nil {
+		log.Fatalf("Failed to parse SUCCESS_NOTIFICATION environment variable: %v", successNotificationErr)
+	}
+
 	config := Settings{
 		ClientUrl:               getEnv("PROST_RPC_URL", ""),
 		ContractAddress:         getEnv("PROTOCOL_STATE_CONTRACT", ""),
@@ -58,6 +64,7 @@ func LoadConfig() {
 		TxRelayerAuthWriteToken: getEnv("TX_RELAYER_AUTH_WRITE_TOKEN", ""),
 		DataMarketAddresses:     dataMarketAddressesList,
 		ProcessSwitch:           processSwitch,
+		SuccessNotification:     successNotification,
 	}
 
 	for _, addr := range config.DataMarketAddresses {

--- a/config/settings.go
+++ b/config/settings.go
@@ -27,7 +27,6 @@ type Settings struct {
 	DataMarketAddresses         []string
 	DataMarketContractAddresses []common.Address
 	ProcessSwitch               bool
-	SuccessNotification         bool
 }
 
 func LoadConfig() {
@@ -47,11 +46,6 @@ func LoadConfig() {
 		log.Fatalf("Failed to parse PROCESS_SWITCH environment variable: %v", processSwitchParseErr)
 	}
 
-	successNotification, successNotificationErr := strconv.ParseBool(getEnv("SUCCESS_NOTIFICATION", "true"))
-	if successNotificationErr != nil {
-		log.Fatalf("Failed to parse SUCCESS_NOTIFICATION environment variable: %v", successNotificationErr)
-	}
-
 	config := Settings{
 		ClientUrl:               getEnv("PROST_RPC_URL", ""),
 		ContractAddress:         getEnv("PROTOCOL_STATE_CONTRACT", ""),
@@ -64,7 +58,6 @@ func LoadConfig() {
 		TxRelayerAuthWriteToken: getEnv("TX_RELAYER_AUTH_WRITE_TOKEN", ""),
 		DataMarketAddresses:     dataMarketAddressesList,
 		ProcessSwitch:           processSwitch,
-		SuccessNotification:     successNotification,
 	}
 
 	for _, addr := range config.DataMarketAddresses {

--- a/pkgs/batcher/submissionFinalizer.go
+++ b/pkgs/batcher/submissionFinalizer.go
@@ -215,8 +215,6 @@ func (s *SubmissionDetails) UpdateEligibleSubmissionCounts(batch map[string][]st
 			log.Errorf("Failed to send updateRewards request to relayer for batch %d, epoch %s in data market %s: %v", s.BatchID, s.EpochID, s.DataMarketAddress, err)
 			return err
 		}
-
-		log.Infof("✅ Successfully sent updateRewards request for batch %d, epoch %s in data market %s", s.BatchID, s.EpochID, s.DataMarketAddress)
 	}
 
 	return nil

--- a/pkgs/batcher/submissionFinalizer.go
+++ b/pkgs/batcher/submissionFinalizer.go
@@ -123,7 +123,7 @@ func (s *SubmissionDetails) FinalizeBatch() (*ipfs.BatchSubmission, error) {
 	log.Infof("🌳 Merkle tree successfully constructed for batch %d, CID %s, epoch %s in data market %s", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress)
 
 	// Submit finalized batch submission to the external tx Relayer service with retry mechanism
-	err = s.submitWithRetries(finalizedBatchSubmission)
+	err = s.sendSubmissionBatchToRelayer(finalizedBatchSubmission)
 	if err != nil {
 		log.Errorf("Failed to send batch %d submission with CID %s to the relayer for epoch %s in data market %s: %v", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress, err)
 		return nil, err
@@ -133,43 +133,6 @@ func (s *SubmissionDetails) FinalizeBatch() (*ipfs.BatchSubmission, error) {
 
 	// Return the finalized batch submission
 	return finalizedBatchSubmission, nil
-}
-
-func (s *SubmissionDetails) submitWithRetries(finalizedBatchSubmission *ipfs.BatchSubmission) error {
-	// Define the operation that will be retried
-	operation := func() error {
-		// Attempt to submit the batch
-		err := clients.SubmitSubmissionBatch(
-			s.DataMarketAddress,
-			finalizedBatchSubmission.CID,
-			s.EpochID,
-			finalizedBatchSubmission.Batch.PIDs,
-			finalizedBatchSubmission.Batch.CIDs,
-			string(finalizedBatchSubmission.FinalizedCIDsRootHash),
-		)
-		if err != nil {
-			log.Errorf("Batch %d submission failed for epoch %s in data market %s: %v. Retrying...", s.BatchID, s.EpochID.String(), s.DataMarketAddress, err)
-			return err // Return error to trigger retry
-		}
-
-		log.Infof("📤 Successfully submitted batch %d with CID %s to relayer for epoch %s in data market %s", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress)
-		return nil // Successful submission, no need for further retries
-	}
-
-	// Customize the backoff configuration
-	backoffConfig := backoff.NewExponentialBackOff()
-	backoffConfig.InitialInterval = 1 * time.Second // Start with a 1-second delay
-	backoffConfig.Multiplier = 1.5                  // Increase interval by 1.5x after each retry
-	backoffConfig.MaxInterval = 4 * time.Second     // Set max interval between retries
-	backoffConfig.MaxElapsedTime = 10 * time.Second // Retry for a maximum of 10 seconds
-
-	// Limit retries to 3 times within 10 seconds
-	if err := backoff.Retry(operation, backoff.WithMaxRetries(backoffConfig, 3)); err != nil {
-		log.Errorf("Failed to submit batch %d submission with CID %s to relayer for epoch %s in data market %s after retries: %v", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress, err)
-		return err
-	}
-
-	return nil
 }
 
 func (s *SubmissionDetails) UpdateEligibleSubmissionCounts(batch map[string][]string, projectMostFrequentCID, submissionSnapshotCIDMap map[string]string) error {
@@ -223,11 +186,86 @@ func (s *SubmissionDetails) UpdateEligibleSubmissionCounts(batch map[string][]st
 		key := redis.EligibleSlotSubmissionKey(s.DataMarketAddress, slotID, currentDay.String())
 		updatedCount, err := redis.IncrBy(context.Background(), key, int64(submissionCount))
 		if err != nil {
-			log.Errorf("Failed to update eligible submission count for slotID %s in epoch %s within data market %s: %v", slotID, s.EpochID, dataMarketAddress, err)
+			log.Errorf("Failed to update eligible submission count for slotID %s in batch %d, epoch %s within data market %s: %v", slotID, s.BatchID, s.EpochID, dataMarketAddress, err)
 			return err
 		}
 
-		log.Debugf("✅ Successfully updated eligible submission count for slotID %s in epoch %s within data market %s: %d", slotID, s.EpochID, dataMarketAddress, updatedCount)
+		log.Debugf("✅ Successfully updated eligible submission count for slotID %s in batch %d, epoch %s within data market %s: %d", slotID, s.BatchID, s.EpochID, dataMarketAddress, updatedCount)
+
+		// Send submission count to relayer only if the current epoch is a multiple of 5
+		if s.EpochID.Int64()%5 == 0 {
+			if err := s.sendEligibleSubmissionCountToRelayer(slotID, currentDay.String(), updatedCount); err != nil {
+				log.Errorf("Failed to send eligible submission count to relayer for slotID %s of batch %d, epoch %s within data market %s: %v", slotID, s.BatchID, s.EpochID, s.DataMarketAddress, err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SubmissionDetails) sendEligibleSubmissionCountToRelayer(slotID, currentDay string, submissionCount int64) error {
+	// Define the operation that will be retried
+	operation := func() error {
+		// Attempt to send the eligible submission count
+		err := clients.SendSubmissionCount(s.DataMarketAddress, slotID, currentDay, s.EpochID, int(submissionCount))
+		if err != nil {
+			log.Errorf("Error sending eligible submission count for slotID %s, batch %d, epoch %s in data market %s: %v. Retrying...", slotID, s.BatchID, s.EpochID.String(), s.DataMarketAddress, err)
+			return err // Return error to trigger retry
+		}
+
+		log.Infof("📤 Successfully sent eligible submission count %d for slotID %s, batch %d, epoch %s to relayer in data market %s", submissionCount, slotID, s.BatchID, s.EpochID.String(), s.DataMarketAddress)
+		return nil // Successful submission, no need for further retries
+	}
+
+	// Customize the backoff configuration
+	backoffConfig := backoff.NewExponentialBackOff()
+	backoffConfig.InitialInterval = 1 * time.Second // Start with a 1-second delay
+	backoffConfig.Multiplier = 1.5                  // Increase interval by 1.5x after each retry
+	backoffConfig.MaxInterval = 4 * time.Second     // Set max interval between retries
+	backoffConfig.MaxElapsedTime = 10 * time.Second // Retry for a maximum of 10 seconds
+
+	// Limit retries to a maximum of 3 attempts within 10 seconds
+	if err := backoff.Retry(operation, backoff.WithMaxRetries(backoffConfig, 3)); err != nil {
+		log.Errorf("Failed to send eligible submission count after retries for slotID %s, batch %d, epoch %s in data market %s: %v", slotID, s.BatchID, s.EpochID.String(), s.DataMarketAddress, err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *SubmissionDetails) sendSubmissionBatchToRelayer(finalizedBatchSubmission *ipfs.BatchSubmission) error {
+	// Define the operation that will be retried
+	operation := func() error {
+		// Attempt to submit the batch
+		err := clients.SubmitSubmissionBatch(
+			s.DataMarketAddress,
+			finalizedBatchSubmission.CID,
+			s.EpochID,
+			finalizedBatchSubmission.Batch.PIDs,
+			finalizedBatchSubmission.Batch.CIDs,
+			string(finalizedBatchSubmission.FinalizedCIDsRootHash),
+		)
+		if err != nil {
+			log.Errorf("Batch %d submission failed for epoch %s in data market %s: %v. Retrying...", s.BatchID, s.EpochID.String(), s.DataMarketAddress, err)
+			return err // Return error to trigger retry
+		}
+
+		log.Infof("📤 Successfully submitted batch %d with CID %s to relayer for epoch %s in data market %s", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress)
+		return nil // Successful submission, no need for further retries
+	}
+
+	// Customize the backoff configuration
+	backoffConfig := backoff.NewExponentialBackOff()
+	backoffConfig.InitialInterval = 1 * time.Second // Start with a 1-second delay
+	backoffConfig.Multiplier = 1.5                  // Increase interval by 1.5x after each retry
+	backoffConfig.MaxInterval = 4 * time.Second     // Set max interval between retries
+	backoffConfig.MaxElapsedTime = 10 * time.Second // Retry for a maximum of 10 seconds
+
+	// Limit retries to 3 times within 10 seconds
+	if err := backoff.Retry(operation, backoff.WithMaxRetries(backoffConfig, 3)); err != nil {
+		log.Errorf("Failed to submit batch %d submission with CID %s to relayer for epoch %s in data market %s after retries: %v", s.BatchID, finalizedBatchSubmission.CID, s.EpochID.String(), s.DataMarketAddress, err)
+		return err
 	}
 
 	return nil

--- a/pkgs/batcher/submissionFinalizer.go
+++ b/pkgs/batcher/submissionFinalizer.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+	"submission-sequencer-finalizer/config"
 	"submission-sequencer-finalizer/pkgs"
 	"submission-sequencer-finalizer/pkgs/clients"
 	"submission-sequencer-finalizer/pkgs/ipfs"
@@ -265,10 +266,12 @@ func (s *SubmissionDetails) UpdateEligibleSubmissionCounts(batch map[string][]st
 			return err
 		}
 
-		// Success message handling
-		successMsg := fmt.Sprintf("✅ Relayer rewards updated successfully: Batch %d, epoch %s in data market %s", s.BatchID, s.EpochID.String(), s.DataMarketAddress)
-		clients.SendFailureNotification(pkgs.SendUpdateRewardsToRelayer, successMsg, time.Now().String(), "High")
-		log.Infof(successMsg)
+		// Success message alert
+		if config.SettingsObj.SuccessNotification {
+			successMsg := fmt.Sprintf("✅ Relayer rewards updated successfully: Batch %d, epoch %s in data market %s", s.BatchID, s.EpochID.String(), s.DataMarketAddress)
+			clients.SendFailureNotification(pkgs.SendUpdateRewardsToRelayer, successMsg, time.Now().String(), "High")
+			log.Infof(successMsg)
+		}
 	}
 
 	return nil

--- a/pkgs/batcher/submissionFinalizer.go
+++ b/pkgs/batcher/submissionFinalizer.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
-	"submission-sequencer-finalizer/config"
 	"submission-sequencer-finalizer/pkgs"
 	"submission-sequencer-finalizer/pkgs/clients"
 	"submission-sequencer-finalizer/pkgs/ipfs"
@@ -264,13 +263,6 @@ func (s *SubmissionDetails) UpdateEligibleSubmissionCounts(batch map[string][]st
 			clients.SendFailureNotification(pkgs.SendUpdateRewardsToRelayer, errorMsg, time.Now().String(), "High")
 			log.Errorf(errorMsg)
 			return err
-		}
-
-		// Success message alert
-		if config.SettingsObj.SuccessNotification {
-			successMsg := fmt.Sprintf("✅ Relayer rewards updated successfully: Batch %d, epoch %s in data market %s", s.BatchID, s.EpochID.String(), s.DataMarketAddress)
-			clients.SendFailureNotification(pkgs.SendUpdateRewardsToRelayer, successMsg, time.Now().String(), "High")
-			log.Infof(successMsg)
 		}
 	}
 

--- a/pkgs/batcher/submissionProcessor.go
+++ b/pkgs/batcher/submissionProcessor.go
@@ -3,13 +3,9 @@ package batcher
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"submission-sequencer-finalizer/config"
-	"submission-sequencer-finalizer/pkgs"
-	"submission-sequencer-finalizer/pkgs/clients"
 	"submission-sequencer-finalizer/pkgs/redis"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -56,9 +52,7 @@ func StartSubmissionProcessor() {
 		// Call the method to finalize the batch submission
 		finalizedBatchSubmission, err := submissionDetails.FinalizeBatch()
 		if err != nil {
-			errorMsg := fmt.Sprintf("Error finalizing batch %d for epoch %s in data market %s: %v", submissionDetails.BatchID, submissionDetails.EpochID.String(), submissionDetails.DataMarketAddress, err)
-			clients.SendFailureNotification(pkgs.FinalizeBatches, errorMsg, time.Now().String(), "High")
-			log.Errorf("Batch finalization failed: %s", errorMsg)
+			log.Errorf("Error finalizing batch %d for epoch %s in data market %s: %v", submissionDetails.BatchID, submissionDetails.EpochID.String(), submissionDetails.DataMarketAddress, err)
 			continue
 		}
 

--- a/pkgs/clients/txClient.go
+++ b/pkgs/clients/txClient.go
@@ -16,13 +16,13 @@ type TxRelayerClient struct {
 	client *http.Client
 }
 
-type EligibleSubmissionCountRequest struct {
-	DataMarketAddress string   `json:"dataMarketAddress"`
-	EpochID           *big.Int `json:"epochID"`
-	SlotID            string   `json:"slotID"`
-	CurrentDay        string   `json:"day"`
-	Count             int      `json:"eligibleSubmissionCount"`
-	AuthToken         string   `json:"authToken"`
+type UpdateRewardsRequest struct {
+	DataMarketAddress string     `json:"dataMarketAddress"`
+	SlotIDs           []*big.Int `json:"slotIDs"`
+	SubmissionsList   []*big.Int `json:"submissionsList"`
+	Day               *big.Int   `json:"day"`
+	EligibleNodes     int        `json:"eligibleNodes"`
+	AuthToken         string     `json:"authToken"`
 }
 
 type SubmitSubmissionBatchRequest struct {
@@ -50,32 +50,32 @@ func InitializeTxClient(url string, timeout time.Duration) {
 	}
 }
 
-// SendSubmissionCount sends submission count data to the transaction relayer service
-func SendSubmissionCount(dataMarketAddress, slotID, currentDay string, epochID *big.Int, submissionCount int) error {
-	request := EligibleSubmissionCountRequest{
+// SendUpdateRewardsRequest sends rewards update data to the transaction relayer service
+func SendUpdateRewardsRequest(dataMarketAddress string, slotIDs, submissionsList []*big.Int, day *big.Int, eligibleNodes int) error {
+	request := UpdateRewardsRequest{
 		DataMarketAddress: dataMarketAddress,
-		EpochID:           epochID,
-		SlotID:            slotID,
-		CurrentDay:        currentDay,
-		Count:             submissionCount,
+		SlotIDs:           slotIDs,
+		SubmissionsList:   submissionsList,
+		Day:               day,
+		EligibleNodes:     eligibleNodes,
 		AuthToken:         config.SettingsObj.TxRelayerAuthWriteToken,
 	}
 
 	jsonData, err := json.Marshal(request)
 	if err != nil {
-		return fmt.Errorf("unable to marshal submission count request: %w", err)
+		return fmt.Errorf("unable to marshal update rewards request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/submitSubmissionCount", txRelayerClient.url)
+	url := fmt.Sprintf("%s/submitUpdateRewards", txRelayerClient.url)
 
 	resp, err := txRelayerClient.client.Post(url, "application/json", bytes.NewBuffer(jsonData))
 	if err != nil {
-		return fmt.Errorf("unable to send submission count request: %w", err)
+		return fmt.Errorf("unable to send update rewards request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to send submission count request, status code: %d", resp.StatusCode)
+		return fmt.Errorf("failed to send update rewards request, status code: %d", resp.StatusCode)
 	}
 
 	return nil

--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -3,11 +3,14 @@ package pkgs
 // Process Name Constants
 // process : identifier
 const (
-	FinalizeBatches         = "FinalizeBatches"
-	BuildMerkleTree         = "BuildMerkleTree"
-	BuildBatchSubmissions   = "BuildBatchSubmissions"
-	ArrangeKeysInBatches    = "ArrangeKeysInBatches"
-	SendSubmissionBatchSize = "SendSubmissionBatchSize"
+	FinalizeBatches                = "FinalizeBatches"
+	BuildMerkleTree                = "BuildMerkleTree"
+	BuildBatchSubmissions          = "BuildBatchSubmissions"
+	ArrangeKeysInBatches           = "ArrangeKeysInBatches"
+	SendSubmissionBatchSize        = "SendSubmissionBatchSize"
+	SendUpdateRewardsToRelayer     = "SendUpdateRewardsToRelayer"
+	SendSubmissionBatchToRelayer   = "SendSubmissionBatchToRelayer"
+	UpdateEligibleSubmissionCounts = "UpdateEligibleSubmissionCounts"
 )
 
 // General Key Constants

--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -15,8 +15,11 @@ const (
 
 // General Key Constants
 const (
-	CurrentDayKey              = "CurrentDayKey"
-	DaySizeTableKey            = "DaySizeTableKey"
-	ProcessTriggerKey          = "TriggeredSequencerProcess"
-	EligibleSlotSubmissionsKey = "EligibleSlotSubmissionsKey"
+	CurrentDayKey                  = "CurrentDayKey"
+	DaySizeTableKey                = "DaySizeTableKey"
+	ProcessTriggerKey              = "TriggeredSequencerProcess"
+	EligibleSlotSubmissionsKey     = "EligibleSlotSubmissionsKey"
+	DailySnapshotQuotaTableKey     = "DailySnapshotQuotaTableKey"
+	EligibleSlotSubmissionByDayKey = "EligibleSlotSubmissionByDayKey"
+	EligibleNodesCountKey          = "EligibleNodesCountKey"
 )

--- a/pkgs/constants.go
+++ b/pkgs/constants.go
@@ -21,5 +21,4 @@ const (
 	EligibleSlotSubmissionsKey     = "EligibleSlotSubmissionsKey"
 	DailySnapshotQuotaTableKey     = "DailySnapshotQuotaTableKey"
 	EligibleSlotSubmissionByDayKey = "EligibleSlotSubmissionByDayKey"
-	EligibleNodesCountKey          = "EligibleNodesCountKey"
 )

--- a/pkgs/prost/contract.go
+++ b/pkgs/prost/contract.go
@@ -75,6 +75,20 @@ func LoadContractStateVariables() {
 				log.Errorf("Failed to set day size for data market %s in Redis: %v", dataMarketAddress.Hex(), err)
 			}
 		}
+
+		// Fetch the daily snapshot quota for the specified data market address from contract
+		if output, err := MustQuery(context.Background(), func() (*big.Int, error) {
+			return Instance.DailySnapshotQuota(&bind.CallOpts{}, dataMarketAddress)
+		}); err == nil {
+			// Convert the daily snapshot quota to a string for storage in Redis
+			dailySnapshotQuota := output.String()
+
+			// Store the daily snapshot quota in the Redis hash table
+			err := redis.RedisClient.HSet(context.Background(), redis.GetDailySnapshotQuotaTableKey(), dataMarketAddress.Hex(), dailySnapshotQuota).Err()
+			if err != nil {
+				log.Errorf("Failed to set daily snapshot quota for data market %s in Redis: %v", dataMarketAddress.Hex(), err)
+			}
+		}
 	}
 }
 

--- a/pkgs/redis/client.go
+++ b/pkgs/redis/client.go
@@ -95,15 +95,6 @@ func IncrBy(ctx context.Context, key string, size int64) (int64, error) {
 	return result, nil
 }
 
-func GetSetCardinality(ctx context.Context, key string) (int, error) {
-	count, err := RedisClient.SCard(ctx, key).Result()
-	if err != nil {
-		return 0, err
-	}
-
-	return int(count), nil
-}
-
 func SetProcessLog(ctx context.Context, key string, logEntry map[string]interface{}, exp time.Duration) error {
 	data, err := json.Marshal(logEntry)
 	if err != nil {

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -10,6 +10,10 @@ func GetDaySizeTableKey() string {
 	return pkgs.DaySizeTableKey
 }
 
+func GetDailySnapshotQuotaTableKey() string {
+	return pkgs.DailySnapshotQuotaTableKey
+}
+
 func GetCurrentDayKey(dataMarketAddress string) string {
 	return fmt.Sprintf("%s.%s", pkgs.CurrentDayKey, strings.ToLower(dataMarketAddress))
 }
@@ -20,4 +24,12 @@ func TriggeredProcessLog(process, identifier string) string {
 
 func EligibleSlotSubmissionKey(dataMarketAddress string, slotID, currentDay string) string {
 	return fmt.Sprintf("%s.%s.%s.%s", pkgs.EligibleSlotSubmissionsKey, strings.ToLower(dataMarketAddress), currentDay, slotID)
+}
+
+func EligibleSlotSubmissionsByDayKey(dataMarketAddress, currentDay string) string {
+	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleSlotSubmissionByDayKey, strings.ToLower(dataMarketAddress), currentDay)
+}
+
+func EligibleNodesCountByDayKey(dataMarketAddress, currentDay string) string {
+	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleSlotSubmissionByDayKey, strings.ToLower(dataMarketAddress), currentDay)
 }

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -31,5 +31,5 @@ func EligibleSlotSubmissionsByDayKey(dataMarketAddress, currentDay string) strin
 }
 
 func EligibleNodesCountByDayKey(dataMarketAddress, currentDay string) string {
-	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleSlotSubmissionByDayKey, strings.ToLower(dataMarketAddress), currentDay)
+	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleNodesCountKey, strings.ToLower(dataMarketAddress), currentDay)
 }

--- a/pkgs/redis/keys.go
+++ b/pkgs/redis/keys.go
@@ -29,7 +29,3 @@ func EligibleSlotSubmissionKey(dataMarketAddress string, slotID, currentDay stri
 func EligibleSlotSubmissionsByDayKey(dataMarketAddress, currentDay string) string {
 	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleSlotSubmissionByDayKey, strings.ToLower(dataMarketAddress), currentDay)
 }
-
-func EligibleNodesCountByDayKey(dataMarketAddress, currentDay string) string {
-	return fmt.Sprintf("%s.%s.%s", pkgs.EligibleNodesCountKey, strings.ToLower(dataMarketAddress), currentDay)
-}


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #4 

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The transaction manager would take care of updating the eligible submission counts for the day for specific slot IDs, against a data market.

### New expected behaviour
The updated eligible submission counts for the day for specific slot IDs, against a data market are now sent to transaction relayer service periodically after every 5 epochs.